### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/sqli/static/js/materialize.js
+++ b/sqli/static/js/materialize.js
@@ -8177,7 +8177,7 @@ if (jQuery) {
                 if ($.isPlainObject(unitToEnable)) {
                   unitToEnable.inverted = true;
                   matchFound = unitToEnable;
-                } else if ($.isArray(unitToEnable)) {
+                } else if (Array.isArray(unitToEnable)) {
                   matchFound = unitToEnable;
                   if (!matchFound[3]) matchFound.push('inverted');
                 } else if (_.isDate(unitToEnable)) {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.
## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.

[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/c6524a4b-da99-482d-b2ef-eba0062f69e1/project/86987959-d25a-47fe-8cb2-17ad6f5e75fa/report/6ec436eb-c705-4bdd-90e6-f82495a689e7/fix/83e25d97-d4d3-4296-8d48-10cade33d178)
